### PR TITLE
refrences regex doesn't escape '.'

### DIFF
--- a/tasks/ver.js
+++ b/tasks/ver.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
           basename: basename,
           version: version,
           renamedBasename: renamedBasename,
-          renamedPath: renamedPath,
+          renamedPath: renamedPath
         };
         simpleVersions[f] = renamedPath;
         numFilesRenamed++;
@@ -62,7 +62,8 @@ module.exports = function(grunt) {
 
           Object.keys(versions).forEach(function(key) {
             var to = versions[key],
-              regex = new RegExp('\\b' + to.basename + '\\b', 'g');
+            escapedBase = to.basename.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&"),
+            regex = new RegExp('\\b' + escapedBase + '\\b', 'g');
 
             content = content.replace(regex, function(match) {
               if (match in replacedToCount) {


### PR DESCRIPTION
When doing the substitutions in references the regex looks like:

```
regex = new RegExp('\\b' + to.basename + '\\b', 'g');
```

So if you have a basename like `foo.js` and a path like `/foo/js/bar.js` the `foo/js` will be replaced when it shouldn't. Before building that regex it would be safer to escape all the regex special characters from `to.basename`, someone on StackOverflow has even already written a regex to do that: http://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/3561711#3561711
