### PR TITLE
Force grunt.file.read(...) to return a Buffer when hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ver",
   "description": "Add hashes to file names and update references to renamed files",
-  "version": "0.5.2",
+  "version": "0.5.3-LUXUS",
   "homepage": "https://github.com/chrisdanford/grunt-ver",
   "author": {
     "name": "Chris Danford",

--- a/tasks/ver.js
+++ b/tasks/ver.js
@@ -128,7 +128,7 @@ module.exports = function(grunt) {
     var hash = crypto.createHash(algorithm);
 
     grunt.log.verbose.writeln('Hashing ' + filePath + '.');
-    hash.update(grunt.file.read(filePath));
+    hash.update(grunt.file.read(filePath, {encoding: null}));
     return hash.digest(encoding);
   };
 


### PR DESCRIPTION
With Node-0.10 I've had consistent MD5s for all types of files.

With Node-0.11+ I've noticed that my image files (mostly jpg) are not being hashed in a consistent manner.  This causing me huge challenges with my S3/CloudFront CDN.  After several hours of debugging testing I think I've discovered that the `grunt.file.read(...)` should be passed an encoding of `null` to force the return of a Buffer.

[See grunt.file.read api docs here](http://gruntjs.com/api/grunt.file#grunt.file.read)

---

Forgive me, but I haven't even looked to see if this breaks any tests, it most certainly should not.
In all honesty, I don't know the first thing about creating or testing Grunt tasks, I just don't have the time to dig into it at the moment.  Hopefully the community can help vet this small change.  Thanks!
